### PR TITLE
Update JSHint (CLI) link's URL & Update course technology policy link 

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,7 +674,7 @@
                 <h4>Wednesday, November 8</h4>
                 <ol>
                   <li>Collaborating on GitHub with Pull Requests</li>
-                  <li><a href="http://jshint.com">JSHint (CLI)</a></li>
+                  <li><a href="http://jshint.com/install/">JSHint (CLI)</a></li>
                   <li>
                     <a href="http://eslint.org/docs/user-guide/command-line-interface">ESLint
                     (CLI)</a>

--- a/policies/index.html
+++ b/policies/index.html
@@ -171,7 +171,7 @@
           </li>
           <li>
             A <a href="https://github.com/">GitHub</a> account (see note about anonymity in the
-            <a href="technology-policy">course technology policy</a> below)
+            <a href="#technology-policy">course technology policy</a> below)
           </li>
           <li>
             The domain of your name (e.g., karlstolley.com belongs to the instructor) or, if privacy


### PR DESCRIPTION
  - Update JSHint (CLI) URL to be JSHint's install
    page as opposed to its home page

- Update to course technology policy link under Required
    Materials and Technologies section for the policies page
    to link to section with id: technology-policy